### PR TITLE
Set valid shell commands as default values

### DIFF
--- a/os/package/drafter-agent/Config.in
+++ b/os/package/drafter-agent/Config.in
@@ -15,13 +15,13 @@ config BR2_PACKAGE_DRAFTER_AGENT_VSOCK_PORT
 
 config BR2_PACKAGE_DRAFTER_AGENT_BEFORE_SUSPEND_CMD
     string "before-suspend-cmd"
-    default ""
+    default "true"
     help
       Command to execute before suspending
 
 config BR2_PACKAGE_DRAFTER_AGENT_AFTER_RESUME_CMD
     string "after-resume-cmd"
-    default ""
+    default "true"
     help
       Command to execute after resuming
 


### PR DESCRIPTION
This fixes the default configuration of the base image by using valid shell commands instead of `""` literals as the default values. Other workarounds such as rendering the shell command literal aren't advisable here since `make`'s default behavior of keeping the `""` literals around is desirable if the shell command is a non-standard value.