### PR TITLE
firecracker: record VM process ID

### DIFF
--- a/internal/firecracker/server.go
+++ b/internal/firecracker/server.go
@@ -36,6 +36,7 @@ const (
 
 type FirecrackerServer struct {
 	VMPath string
+	VMPid  int
 	Wait   func() error
 	Close  func() error
 }
@@ -136,6 +137,7 @@ func StartFirecrackerServer(
 	if err := cmd.Start(); err != nil {
 		panic(errors.Join(ErrCouldNotStartFirecrackerServer, err))
 	}
+	server.VMPid = cmd.Process.Pid
 
 	var closeLock sync.Mutex
 	closed := false

--- a/pkg/roles/peer.go
+++ b/pkg/roles/peer.go
@@ -222,6 +222,7 @@ type peerStage5 struct {
 
 type Peer struct {
 	VMPath string
+	VMPid  int
 
 	Wait  func() error
 	Close func() error
@@ -299,6 +300,7 @@ func StartPeer(
 	}
 
 	peer.VMPath = runner.VMPath
+	peer.VMPid = runner.VMPid
 
 	// We don't track this because we return the wait function
 	handleGoroutinePanics(false, func() {

--- a/pkg/roles/runner.go
+++ b/pkg/roles/runner.go
@@ -64,6 +64,7 @@ type SnapshotLoadConfiguration struct {
 
 type Runner struct {
 	VMPath string
+	VMPid  int
 
 	Wait  func() error
 	Close func() error
@@ -173,6 +174,7 @@ func StartRunner(
 	}
 
 	runner.VMPath = server.VMPath
+	runner.VMPid = server.VMPid
 
 	// We intentionally don't call `wg.Add` and `wg.Done` here since we return the process's wait method
 	// We still need to `defer handleGoroutinePanic()()` here however so that we catch any errors during this call


### PR DESCRIPTION
After the VM is started, it's sometimes necessary to interact with the `firecracker` process directly, which requires knowing its PID.

Record the `firecracker` process ID when it starts and bubble it up to the peer.