### PR TITLE
net: update VM IPs to use private values

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,9 +960,9 @@ Usage of drafter-nat:
   -namespace-interface string
         Name for the interface inside the namespace (default "tap0")
   -namespace-interface-gateway string
-        Gateway for the interface inside the namespace (default "172.100.100.1")
+        Gateway for the interface inside the namespace (default "172.16.0.1")
   -namespace-interface-ip string
-        IP for the interface inside the namespace (default "172.100.100.2")
+        IP for the interface inside the namespace (default "172.16.0.2")
   -namespace-interface-mac string
         MAC address for the interface inside the namespace (default "02:0e:d9:fd:68:3d")
   -namespace-interface-netmask uint

--- a/cmd/drafter-nat/main.go
+++ b/cmd/drafter-nat/main.go
@@ -19,9 +19,9 @@ func main() {
 	blockedSubnetCIDR := flag.String("blocked-subnet-cidr", "10.0.15.0/24", "CIDR to block for the namespace")
 
 	namespaceInterface := flag.String("namespace-interface", "tap0", "Name for the interface inside the namespace")
-	namespaceInterfaceGateway := flag.String("namespace-interface-gateway", "172.100.100.1", "Gateway for the interface inside the namespace")
+	namespaceInterfaceGateway := flag.String("namespace-interface-gateway", "172.16.0.1", "Gateway for the interface inside the namespace")
 	namespaceInterfaceNetmask := flag.Uint("namespace-interface-netmask", 30, "Netmask for the interface inside the namespace")
-	namespaceInterfaceIP := flag.String("namespace-interface-ip", "172.100.100.2", "IP for the interface inside the namespace")
+	namespaceInterfaceIP := flag.String("namespace-interface-ip", "172.16.0.2", "IP for the interface inside the namespace")
 	namespaceInterfaceMAC := flag.String("namespace-interface-mac", "02:0e:d9:fd:68:3d", "MAC address for the interface inside the namespace")
 
 	namespacePrefix := flag.String("namespace-prefix", "ark", "Prefix for the namespace IDs")

--- a/os/board/firecracker-aarch64/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-aarch64/overlay/etc/systemd/network/10-eth0.network
@@ -2,5 +2,5 @@
 Name=eth0
 
 [Network]
-Address=172.100.100.2/30
-Gateway=172.100.100.1
+Address=172.16.0.2/30
+Gateway=172.16.0.1

--- a/os/board/firecracker-x86_64/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-x86_64/overlay/etc/systemd/network/10-eth0.network
@@ -2,5 +2,5 @@
 Name=eth0
 
 [Network]
-Address=172.100.100.2/30
-Gateway=172.100.100.1
+Address=172.16.0.2/30
+Gateway=172.16.0.1

--- a/os/board/firecracker-x86_64_pvm/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-x86_64_pvm/overlay/etc/systemd/network/10-eth0.network
@@ -2,5 +2,5 @@
 Name=eth0
 
 [Network]
-Address=172.100.100.2/30
-Gateway=172.100.100.1
+Address=172.16.0.2/30
+Gateway=172.16.0.1


### PR DESCRIPTION
172.100.100.1 and 172.100.100.2 are public IPs and would be unroutable if used by the VM network interfaces. The substitute values (172.16.0.1 and 172.16.0.2) are part of the private range 172.16.0.0/12.