### PR TITLE
os: set MTU value for guest OS eth0 interfaces

### DIFF
--- a/os/board/firecracker-aarch64/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-aarch64/overlay/etc/systemd/network/10-eth0.network
@@ -4,3 +4,6 @@ Name=eth0
 [Network]
 Address=172.16.0.2/30
 Gateway=172.16.0.1
+
+[Link]
+MTUBytes=1460

--- a/os/board/firecracker-x86_64/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-x86_64/overlay/etc/systemd/network/10-eth0.network
@@ -4,3 +4,6 @@ Name=eth0
 [Network]
 Address=172.16.0.2/30
 Gateway=172.16.0.1
+
+[Link]
+MTUBytes=1460

--- a/os/board/firecracker-x86_64_pvm/overlay/etc/systemd/network/10-eth0.network
+++ b/os/board/firecracker-x86_64_pvm/overlay/etc/systemd/network/10-eth0.network
@@ -4,3 +4,6 @@ Name=eth0
 [Network]
 Address=172.16.0.2/30
 Gateway=172.16.0.1
+
+[Link]
+MTUBytes=1460


### PR DESCRIPTION
Mismatched MTU values during packet transmission may result in packet fragmentation, causing eBPF code to mishandle them and generating unexpected network traffic errors.

So far we have found 1460 to be a somewhat lowest-common-denominator for regular network traffic across the Internet. This value may be adjusted in the future as we collect more data.