### PR TITLE
Initial impl moved dirtyTracker and volatilityMonitor up

### DIFF
--- a/pkg/peer/make_migratable.go
+++ b/pkg/peer/make_migratable.go
@@ -10,9 +10,7 @@ import (
 	"github.com/loopholelabs/drafter/pkg/runner"
 	"github.com/loopholelabs/goroutine-manager/pkg/manager"
 	"github.com/loopholelabs/silo/pkg/storage/blocks"
-	"github.com/loopholelabs/silo/pkg/storage/dirtytracker"
 	"github.com/loopholelabs/silo/pkg/storage/modules"
-	"github.com/loopholelabs/silo/pkg/storage/volatilitymonitor"
 )
 
 type ResumedPeer[L ipc.AgentServerLocal, R ipc.AgentServerRemote[G], G any] struct {
@@ -79,10 +77,8 @@ func (resumedPeer *ResumedPeer[L, R, G]) MakeMigratable(
 		stage3Inputs,
 		func(index int, input makeMigratableFilterStage, output *makeMigratableDeviceStage, addDefer func(deferFunc func() error)) error {
 			output.prev = input
-
-			dirtyLocal, dirtyRemote := dirtytracker.NewDirtyTracker(input.prev.storage, int(input.prev.blockSize))
-			output.dirtyRemote = dirtyRemote
-			monitor := volatilitymonitor.NewVolatilityMonitor(dirtyLocal, int(input.prev.blockSize), input.makeMigratableDevice.Expiry)
+			output.dirtyRemote = input.prev.dirtyRemote
+			monitor := input.prev.volatilityMonitor
 
 			local := modules.NewLockable(monitor)
 			output.storage = local

--- a/pkg/peer/migrate_from.go
+++ b/pkg/peer/migrate_from.go
@@ -203,6 +203,7 @@ func (peer *Peer[L, R, G]) MigrateFrom(
 
 						dirtyLocal, dirtyRemote := dirtytracker.NewDirtyTracker(local, int(di.BlockSize))
 						vmonitor := volatilitymonitor.NewVolatilityMonitor(dirtyLocal, int(di.BlockSize), volatilityExpiry)
+						vmonitor.AddAll()
 
 						dev.SetProvider(vmonitor)
 
@@ -507,6 +508,7 @@ func (peer *Peer[L, R, G]) MigrateFrom(
 
 				dirtyLocal, dirtyRemote := dirtytracker.NewDirtyTracker(local, int(input.BlockSize))
 				vmonitor := volatilitymonitor.NewVolatilityMonitor(dirtyLocal, int(input.BlockSize), volatilityExpiry)
+				vmonitor.AddAll()
 
 				dev.SetProvider(vmonitor)
 

--- a/pkg/peer/migrate_from.go
+++ b/pkg/peer/migrate_from.go
@@ -201,10 +201,10 @@ func (peer *Peer[L, R, G]) MigrateFrom(
 							}
 						}
 
-						dev.SetProvider(local)
-
 						dirtyLocal, dirtyRemote := dirtytracker.NewDirtyTracker(local, int(di.BlockSize))
 						vmonitor := volatilitymonitor.NewVolatilityMonitor(dirtyLocal, int(di.BlockSize), volatilityExpiry)
+
+						dev.SetProvider(vmonitor)
 
 						stage2InputsLock.Lock()
 						migratedPeer.stage2Inputs = append(migratedPeer.stage2Inputs, migrateFromStage{
@@ -505,10 +505,10 @@ func (peer *Peer[L, R, G]) MigrateFrom(
 				addDefer(local.Close)
 				addDefer(dev.Shutdown)
 
-				dev.SetProvider(local)
-
 				dirtyLocal, dirtyRemote := dirtytracker.NewDirtyTracker(local, int(input.BlockSize))
 				vmonitor := volatilitymonitor.NewVolatilityMonitor(dirtyLocal, int(input.BlockSize), volatilityExpiry)
+
+				dev.SetProvider(vmonitor)
 
 				stage2InputsLock.Lock()
 				migratedPeer.stage2Inputs = append(migratedPeer.stage2Inputs, migrateFromStage{

--- a/pkg/peer/stages.go
+++ b/pkg/peer/stages.go
@@ -6,6 +6,7 @@ import (
 	"github.com/loopholelabs/silo/pkg/storage/blocks"
 	"github.com/loopholelabs/silo/pkg/storage/dirtytracker"
 	"github.com/loopholelabs/silo/pkg/storage/modules"
+	"github.com/loopholelabs/silo/pkg/storage/volatilitymonitor"
 )
 
 type migrateFromStage struct {
@@ -16,8 +17,11 @@ type migrateFromStage struct {
 	id     uint32
 	remote bool
 
-	storage storage.Provider
-	device  storage.ExposedStorage
+	storage           storage.Provider
+	device            storage.ExposedStorage
+	dirtyLocal        *dirtytracker.Local
+	dirtyRemote       *dirtytracker.Remote
+	volatilityMonitor *volatilitymonitor.VolatilityMonitor
 }
 
 type makeMigratableFilterStage struct {


### PR DESCRIPTION
This moves dirtyTracker and crucially volatilityMonitor up the chain to when devices are created.
Currently volatilityMonitors are not created until a connection is received to migrate, so Silo doesn't have a good picture of what order to migrate devices. This PR should fix that.