### PR TITLE
Add support for custom payloads on device authority transfer

### DIFF
--- a/cmd/drafter-mounter/main.go
+++ b/cmd/drafter-mounter/main.go
@@ -262,8 +262,8 @@ func main() {
 			OnRemoteDeviceExposed: func(remoteDeviceID uint32, path string) {
 				log.Println("Exposed remote device", remoteDeviceID, "at", path)
 			},
-			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32) {
-				log.Println("Received authority for remote device", remoteDeviceID)
+			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32, customPayload []byte) {
+				log.Println("Received authority for remote device", remoteDeviceID, "with custom payload", customPayload)
 			},
 			OnRemoteDeviceMigrationCompleted: func(remoteDeviceID uint32) {
 				log.Println("Completed migration of remote device", remoteDeviceID)
@@ -479,6 +479,18 @@ l:
 						} else {
 							log.Println("Getting dirty blocks for local device", deviceID)
 						}
+					},
+
+					OnBeforeSendDeviceAuthority: func(deviceID uint32, remote bool) []byte {
+						var customPayload []byte
+
+						if remote {
+							log.Println("Sending authority for remote device", deviceID, "with custom payload", customPayload)
+						} else {
+							log.Println("Sending authority for local device", deviceID, "with custom payload", customPayload)
+						}
+
+						return customPayload
 					},
 
 					OnDeviceSent: func(deviceID uint32, remote bool) {

--- a/cmd/drafter-mounter/main.go
+++ b/cmd/drafter-mounter/main.go
@@ -263,7 +263,7 @@ func main() {
 				log.Println("Exposed remote device", remoteDeviceID, "at", path)
 			},
 			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32, customPayload []byte) {
-				log.Println("Received authority for remote device", remoteDeviceID, "with custom payload", customPayload)
+				log.Println("Received authority for remote device", remoteDeviceID)
 			},
 			OnRemoteDeviceMigrationCompleted: func(remoteDeviceID uint32) {
 				log.Println("Completed migration of remote device", remoteDeviceID)

--- a/cmd/drafter-peer/main.go
+++ b/cmd/drafter-peer/main.go
@@ -360,7 +360,7 @@ func main() {
 				log.Println("Exposed remote device", remoteDeviceID, "at", path)
 			},
 			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32, customPayload []byte) {
-				log.Println("Received authority for remote device", remoteDeviceID, "with custom payload", customPayload)
+				log.Println("Received authority for remote device", remoteDeviceID)
 			},
 			OnRemoteDeviceMigrationCompleted: func(remoteDeviceID uint32) {
 				log.Println("Completed migration of remote device", remoteDeviceID)

--- a/cmd/drafter-peer/main.go
+++ b/cmd/drafter-peer/main.go
@@ -359,8 +359,8 @@ func main() {
 			OnRemoteDeviceExposed: func(remoteDeviceID uint32, path string) {
 				log.Println("Exposed remote device", remoteDeviceID, "at", path)
 			},
-			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32) {
-				log.Println("Received authority for remote device", remoteDeviceID)
+			OnRemoteDeviceAuthorityReceived: func(remoteDeviceID uint32, customPayload []byte) {
+				log.Println("Received authority for remote device", remoteDeviceID, "with custom payload", customPayload)
 			},
 			OnRemoteDeviceMigrationCompleted: func(remoteDeviceID uint32) {
 				log.Println("Completed migration of remote device", remoteDeviceID)
@@ -624,6 +624,18 @@ func main() {
 			},
 			OnAfterSuspend: func() {
 				log.Println("Suspend:", time.Since(before))
+			},
+
+			OnBeforeSendDeviceAuthority: func(deviceID uint32, remote bool) []byte {
+				var customPayload []byte
+
+				if remote {
+					log.Println("Sending authority for remote device", deviceID, "with custom payload", customPayload)
+				} else {
+					log.Println("Sending authority for local device", deviceID, "with custom payload", customPayload)
+				}
+
+				return customPayload
 			},
 
 			OnDeviceSent: func(deviceID uint32, remote bool) {

--- a/pkg/mounter/migrate_from.go
+++ b/pkg/mounter/migrate_from.go
@@ -37,7 +37,7 @@ type MigrateFromAndMountDevice struct {
 type MigrateFromHooks struct {
 	OnRemoteDeviceReceived           func(remoteDeviceID uint32, name string)
 	OnRemoteDeviceExposed            func(remoteDeviceID uint32, path string)
-	OnRemoteDeviceAuthorityReceived  func(remoteDeviceID uint32)
+	OnRemoteDeviceAuthorityReceived  func(remoteDeviceID uint32, customPayload []byte)
 	OnRemoteDeviceMigrationCompleted func(remoteDeviceID uint32)
 
 	OnRemoteAllDevicesReceived     func()
@@ -258,12 +258,12 @@ func MigrateFromAndMount(
 								}
 
 							case byte(registry.EventCustomTransferAuthority):
-								if receivedButNotReadyRemoteDevices.Add(-1) <= 0 {
-									signalAllRemoteDevicesReady()
+								if hook := hooks.OnRemoteDeviceAuthorityReceived; hook != nil {
+									hook(index, e.CustomPayload)
 								}
 
-								if hook := hooks.OnRemoteDeviceAuthorityReceived; hook != nil {
-									hook(index)
+								if receivedButNotReadyRemoteDevices.Add(-1) <= 0 {
+									signalAllRemoteDevicesReady()
 								}
 							}
 

--- a/pkg/mounter/migrate_to.go
+++ b/pkg/mounter/migrate_to.go
@@ -20,6 +20,12 @@ import (
 type MounterMigrateToHooks struct {
 	OnBeforeGetDirtyBlocks func(deviceID uint32, remote bool)
 
+	// This is called before a device authority is transferred;
+	// the return value will be sent as the custom payload for
+	// the registry.EventCustomTransferAuthority event and can be
+	// received in OnRemoteDeviceAuthorityReceived on the destination
+	OnBeforeSendDeviceAuthority func(deviceID uint32, remote bool) []byte
+
 	OnDeviceSent                       func(deviceID uint32, remote bool)
 	OnDeviceAuthoritySent              func(deviceID uint32, remote bool)
 	OnDeviceInitialMigrationProgress   func(deviceID uint32, remote bool, ready int, total int)
@@ -359,9 +365,15 @@ func (migratableMounter *MigratableMounter) MigrateTo(
 				}
 			}
 
+			var customPayload []byte
+			if hook := hooks.OnBeforeSendDeviceAuthority; hook != nil {
+				customPayload = hook(uint32(index), input.prev.prev.prev.remote)
+			}
+
 			if err := to.SendEvent(&packets.Event{
-				Type:       packets.EventCustom,
-				CustomType: byte(registry.EventCustomTransferAuthority),
+				Type:          packets.EventCustom,
+				CustomType:    byte(registry.EventCustomTransferAuthority),
+				CustomPayload: customPayload,
 			}); err != nil {
 				panic(errors.Join(ErrCouldNotSendTransferAuthorityEvent, err))
 			}

--- a/pkg/peer/migrate_from.go
+++ b/pkg/peer/migrate_from.go
@@ -283,12 +283,12 @@ func (peer *Peer[L, R, G]) MigrateFrom(
 								}
 
 							case byte(registry.EventCustomTransferAuthority):
-								if receivedButNotReadyRemoteDevices.Add(-1) <= 0 {
-									signalAllRemoteDevicesReady()
+								if hook := hooks.OnRemoteDeviceAuthorityReceived; hook != nil {
+									hook(index, e.CustomPayload)
 								}
 
-								if hook := hooks.OnRemoteDeviceAuthorityReceived; hook != nil {
-									hook(index)
+								if receivedButNotReadyRemoteDevices.Add(-1) <= 0 {
+									signalAllRemoteDevicesReady()
 								}
 							}
 


### PR DESCRIPTION
This adds support for sending and receiving custom payloads on device authority transfers through `OnBeforeSendDeviceAuthority` and `OnRemoteDeviceAuthorityReceived`, which makes it possible to transfer instance metadata through the Silo event system in a single RTT.