### PR TITLE
Add back guest services to peer

### DIFF
--- a/cmd/drafter-peer/main.go
+++ b/cmd/drafter-peer/main.go
@@ -85,7 +85,7 @@ func main() {
 		panic(err)
 	}
 
-	p, err := peer.StartPeer(ctx,
+	p, err := peer.StartPeer[struct{}, ipc.AgentServerRemote[struct{}]](ctx,
 		context.Background(), // Never give up on rescue operations
 
 		snapshotter.HypervisorConfiguration{


### PR DESCRIPTION
At some point in #63 the ability to pass in guest service types was removed; this adds back this functionality by passing the generics from the peer to the runner again.