### PR TITLE
Invoke `OnCompletion` hook for both local and remote devices

### DIFF
--- a/cmd/drafter-peer/main.go
+++ b/cmd/drafter-peer/main.go
@@ -58,7 +58,7 @@ func main() {
 
 	serveMetrics := flag.String("metrics", "", "Address to serve metrics from")
 
-	disablePostCopyMigration := flag.Bool("disable-postcopy-migration", false, "Whether to disable post-copy migration")
+	disablePostcopyMigration := flag.Bool("disable-postcopy-migration", false, "Whether to disable post-copy migration")
 
 	flag.Parse()
 
@@ -227,7 +227,7 @@ func main() {
 		panic(err)
 	}
 
-	if !*disablePostCopyMigration {
+	if !*disablePostcopyMigration {
 		select {
 		case <-ctx.Done():
 		case <-ready:

--- a/pkg/peer/peer.go
+++ b/pkg/peer/peer.go
@@ -237,6 +237,10 @@ func (peer *Peer) MigrateFrom(ctx context.Context, devices []common.MigrateFromD
 		if hook := hooks.OnLocalAllDevicesRequested; hook != nil {
 			hook()
 		}
+
+		if hooks.OnCompletion != nil {
+			go hooks.OnCompletion()
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR makes sure that the `OnCompletion` hook gets called for local and remote devices, and adds that check to the tests.

PR has a soft dependency on https://github.com/loopholelabs/silo/pull/76 to verify that this works with S3 too