### PR TITLE
Bump Buildroot and build system conventions

### DIFF
--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -1,0 +1,256 @@
+name: architect CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  test:
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{matrix.target.id}}"
+      src: "${{matrix.target.src}}"
+      os: "${{matrix.target.os}}"
+      flags: "${{matrix.target.flags}}"
+      cmd: "${{matrix.target.cmd}}"
+      dst: "${{matrix.target.dst}}"
+      runner: "${{matrix.target.runner}}"
+    strategy:
+      matrix:
+        target:
+          - id: test
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build --privileged --cap-add=ALL -v /lib/modules:/lib/modules:ro -v /dev:/dev -v /var/run/docker.sock:/var/run/docker.sock --network host'
+            cmd: ./Hydrunfile test
+            dst: out/nonexistent
+            runner: depot-ubuntu-22.04-32
+
+  build-binaries:
+    needs: test
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{ matrix.target.id }}"
+      src: "${{ matrix.target.src }}"
+      os: "${{ matrix.target.os }}"
+      flags: "${{ matrix.target.flags }}"
+      cmd: "${{ matrix.target.cmd }}"
+      dst: "${{ matrix.target.dst }}"
+      runner: "${{ matrix.target.runner }}"
+    strategy:
+      matrix:
+        target:
+          - id: go.drafter-nat
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-nat
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-forwarder
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-forwarder
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-agent
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-agent
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-liveness
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-liveness
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-snapshotter
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-snapshotter
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-peer
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-peer
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+
+  publish-binaries:
+    needs: build-binaries
+    uses: ./.github/workflows/publish.yaml
+    permissions:
+      id-token: write
+      contents: write
+    secrets: inherit
+
+  build-os:
+    needs: test
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{ matrix.target.id }}"
+      src: "${{ matrix.target.src }}"
+      os: "${{ matrix.target.os }}"
+      flags: "${{ matrix.target.flags }}"
+      cmd: "${{ matrix.target.cmd }}"
+      dst: "${{ matrix.target.dst }}"
+      runner: "${{ matrix.target.runner }}"
+    strategy:
+      matrix:
+        target:
+          # OCI OS
+          - id: os.drafteros-oci-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_defconfig drafteros-oci-x86_64.tar.zst
+            dst: out/drafteros-oci-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-oci-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_pvm_defconfig drafteros-oci-x86_64_pvm.tar.zst
+            dst: out/drafteros-oci-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-oci-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-aarch64_defconfig drafteros-oci-aarch64.tar.zst
+            dst: out/drafteros-oci-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # k3s Server OS
+          - id: os.drafteros-k3s-server-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_defconfig drafteros-k3s-server-x86_64.tar.zst
+            dst: out/drafteros-k3s-server-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-server-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_pvm_defconfig drafteros-k3s-server-x86_64_pvm.tar.zst
+            dst: out/drafteros-k3s-server-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-server-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-aarch64_defconfig drafteros-k3s-server-aarch64.tar.zst
+            dst: out/drafteros-k3s-server-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # k3s Client OS
+          - id: os.drafteros-k3s-client-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_defconfig drafteros-k3s-client-x86_64.tar.zst
+            dst: out/drafteros-k3s-client-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-client-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_pvm_defconfig drafteros-k3s-client-x86_64_pvm.tar.zst
+            dst: out/drafteros-k3s-client-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-client-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-aarch64_defconfig drafteros-k3s-client-aarch64.tar.zst
+            dst: out/drafteros-k3s-client-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # OCI runtime bundles
+          - id: oci.valkey-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://valkey/valkey:latest amd64 oci-valkey-x86_64.tar.zst
+            dst: out/oci-valkey-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.valkey-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://valkey/valkey:latest arm64 oci-valkey-aarch64.tar.zst
+            dst: out/oci-valkey-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.postgres-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://postgres:latest amd64 oci-postgres-x86_64.tar.zst
+            dst: out/oci-postgres-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.postgres-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://postgres:latest arm64 oci-postgres-aarch64.tar.zst
+            dst: out/oci-postgres-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.ollama-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://ollama/ollama:latest amd64 oci-ollama-x86_64.tar.zst
+            dst: out/oci-ollama-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.ollama-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://ollama/ollama:latest arm64 oci-ollama-aarch64.tar.zst
+            dst: out/oci-ollama-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+  integration:
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    concurrency:
+      group: integration # Only one integration test can run in the repository at a time across all refs
+    with:
+      id: "${{matrix.target.id}}"
+      src: "${{matrix.target.src}}"
+      os: "${{matrix.target.os}}"
+      flags: "${{matrix.target.flags}}"
+      cmd: "${{matrix.target.cmd}}"
+      dst: "${{matrix.target.dst}}"
+      runner: "${{matrix.target.runner}}"
+    strategy:
+      matrix:
+        target:
+          - id: "integration"
+            src: "."
+            os: fedora:42
+            flags: "-e '-v /tmp/ssh-key:/tmp/ssh-key -v /tmp/ccache:/root/.cache/go-build -v /tmp/google-credentials:/tmp/google-credentials'"
+            cmd: "./Hydrunfile integration"
+            dst: "out/nonexistent"
+            runner: "depot-ubuntu-22.04-32"
+
+  publish-os:
+    needs: build-os
+    uses: ./.github/workflows/publish.yaml
+    permissions:
+      id-token: write
+      contents: write
+    secrets: inherit

--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -1,4 +1,4 @@
-name: architect CI
+name: Drafter CI
 
 on:
   push:

--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -1,252 +1,76 @@
-name: hydrun CI
+name: Build with Hydrun
 
 on:
-  workflow_dispatch
-#  push:
-#    paths-ignore:
-#      - ".github/signatures/**"
-#  pull_request:
-#    paths-ignore:
-#      - ".github/signatures/**"
-#  schedule:
-#    - cron: "0 0 * * 0"
+  workflow_call:
+    inputs:
+      id:
+        type: string
+        required: true
+      src:
+        type: string
+        required: true
+      os:
+        type: string
+        required: true
+      flags:
+        type: string
+        required: false
+      cmd:
+        type: string
+        required: false
+      dst:
+        type: string
+        required: false
+      runner:
+        type: string
+        required: true
 
 jobs:
-  build-linux:
-    runs-on: ${{ matrix.target.runner }}
+  build:
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
-    strategy:
-      matrix:
-        target:
-          # Tests
-          - id: test
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build --privileged --cap-add=ALL -v /lib/modules:/lib/modules:ro -v /dev:/dev -v /var/run/docker.sock:/var/run/docker.sock --network host'
-            cmd: ./Hydrunfile test
-            dst: out/nonexistent
-            runner: depot-ubuntu-22.04-32
-
-          # Binaries
-          - id: go.drafter-nat
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-nat
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-forwarder
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-forwarder
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-agent
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-agent
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-liveness
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-liveness
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-snapshotter
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-snapshotter
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-peer
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-peer
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-
-          # OCI OS
-          - id: os.drafteros-oci-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_defconfig drafteros-oci-x86_64.tar.zst
-            dst: out/drafteros-oci-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-oci-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_pvm_defconfig drafteros-oci-x86_64_pvm.tar.zst
-            dst: out/drafteros-oci-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-oci-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-aarch64_defconfig drafteros-oci-aarch64.tar.zst
-            dst: out/drafteros-oci-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # k3s Server OS
-          - id: os.drafteros-k3s-server-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_defconfig drafteros-k3s-server-x86_64.tar.zst
-            dst: out/drafteros-k3s-server-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-server-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_pvm_defconfig drafteros-k3s-server-x86_64_pvm.tar.zst
-            dst: out/drafteros-k3s-server-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-server-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-aarch64_defconfig drafteros-k3s-server-aarch64.tar.zst
-            dst: out/drafteros-k3s-server-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # k3s Client OS
-          - id: os.drafteros-k3s-client-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_defconfig drafteros-k3s-client-x86_64.tar.zst
-            dst: out/drafteros-k3s-client-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-client-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_pvm_defconfig drafteros-k3s-client-x86_64_pvm.tar.zst
-            dst: out/drafteros-k3s-client-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-client-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-aarch64_defconfig drafteros-k3s-client-aarch64.tar.zst
-            dst: out/drafteros-k3s-client-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # OCI runtime bundles
-          - id: oci.valkey-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://valkey/valkey:latest amd64 oci-valkey-x86_64.tar.zst
-            dst: out/oci-valkey-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.valkey-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://valkey/valkey:latest arm64 oci-valkey-aarch64.tar.zst
-            dst: out/oci-valkey-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.postgres-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://postgres:latest amd64 oci-postgres-x86_64.tar.zst
-            dst: out/oci-postgres-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.postgres-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://postgres:latest arm64 oci-postgres-aarch64.tar.zst
-            dst: out/oci-postgres-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.ollama-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://ollama/ollama:latest amd64 oci-ollama-x86_64.tar.zst
-            dst: out/oci-ollama-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.ollama-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://ollama/ollama:latest arm64 oci-ollama-aarch64.tar.zst
-            dst: out/oci-ollama-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Restore ccache
         uses: actions/cache/restore@v4
         with:
           path: |
             /tmp/ccache
-          key: cache-ccache-${{ matrix.target.id }}
+          key: cache-ccache-${{ inputs.id }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Set up hydrun
         run: |
           curl -L -o /tmp/hydrun "https://github.com/pojntfx/hydrun/releases/latest/download/hydrun.linux-$(uname -m)"
           sudo install /tmp/hydrun /usr/local/bin
+
       - name: Build with hydrun
-        working-directory: ${{ matrix.target.src }}
-        run: hydrun -o ${{ matrix.target.os }} ${{ matrix.target.flags }} "${{ matrix.target.cmd }}"
+        working-directory: ${{ inputs.src }}
+        timeout-minutes: 120
+        run: |
+          hydrun -o ${{ inputs.os }} ${{ inputs.flags }} "${{ inputs.cmd }}"
+
       - name: Fix permissions for output
         run: sudo chown -R $USER .
+
       - name: Save ccache
         uses: actions/cache/save@v4
         with:
           path: |
             /tmp/ccache
-          key: cache-ccache-${{ matrix.target.id }}
+          key: cache-ccache-${{ inputs.id }}
+
       - name: Upload output
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target.id }}
-          path: ${{ matrix.target.dst }}
-
-  publish-linux:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: build-linux
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download output
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/out
-      - name: Extract branch name
-        id: extract_branch
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      - name: Publish pre-release to GitHub releases
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: release-${{ steps.extract_branch.outputs.branch }}
-          prerelease: true
-          files: |
-            /tmp/out/*/*
-      - name: Publish release to GitHub releases
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: false
-          files: |
-            /tmp/out/*/*
+          name: ${{ inputs.id }}
+          path: ${{ inputs.dst }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish Artifacts
+
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download output
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/out
+
+      - name: Publish pre-release to GitHub releases
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ github.ref_name }}
+          prerelease: true
+          files: |
+            /tmp/out/*/*
+
+      - name: Publish release to GitHub releases
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          files: |
+            /tmp/out/*/*

--- a/Hydrunfile
+++ b/Hydrunfile
@@ -2,6 +2,8 @@
 
 set -e
 
+export CI=true
+
 # Test
 if [ "$1" = "test" ]; then
   # Install native dependencies
@@ -48,7 +50,7 @@ fi
 # OS
 if [ "$1" = "os" ]; then
   # Install native dependencies
-  dnf install -y @c-development @development-tools go curl make file cpio unzip rsync bc openssh-clients which wget perl
+  dnf install -y @c-development @development-tools go curl make file cpio unzip rsync bc openssh-clients which wget perl awk
 
   # Configure Git
   git config --global --add safe.directory '*'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OCI_IMAGE_URI ?= docker://valkey/valkey:latest
 OCI_IMAGE_ARCHITECTURE ?= amd64
 OCI_IMAGE_HOSTNAME ?= drafterguest
 
-OS_URL ?= https://buildroot.org/downloads/buildroot-2024.11.tar.gz
+OS_URL ?= https://github.com/loopholelabs/buildroot/archive/8958adcacfec580cda9ee5ff049017a9f64a6996.tar.gz
 OS_DEFCONFIG ?= drafteros-oci-firecracker-x86_64_defconfig
 OS_BR2_EXTERNAL ?= ../../os
 


### PR DESCRIPTION
This bumps Buildroot for Go 1.24 support (pinned to a specific commit while we wait for https://patchwork.ozlabs.org/project/buildroot/list/?series=451046 to be merged) and uses the latest build conventions.