### PR TITLE
Add option to work around log streaming issues

### DIFF
--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -1,0 +1,256 @@
+name: architect CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  test:
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{matrix.target.id}}"
+      src: "${{matrix.target.src}}"
+      os: "${{matrix.target.os}}"
+      flags: "${{matrix.target.flags}}"
+      cmd: "${{matrix.target.cmd}}"
+      dst: "${{matrix.target.dst}}"
+      runner: "${{matrix.target.runner}}"
+    strategy:
+      matrix:
+        target:
+          - id: test
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build --privileged --cap-add=ALL -v /lib/modules:/lib/modules:ro -v /dev:/dev -v /var/run/docker.sock:/var/run/docker.sock --network host'
+            cmd: ./Hydrunfile test
+            dst: out/nonexistent
+            runner: depot-ubuntu-22.04-32
+
+  build-binaries:
+    needs: test
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{ matrix.target.id }}"
+      src: "${{ matrix.target.src }}"
+      os: "${{ matrix.target.os }}"
+      flags: "${{ matrix.target.flags }}"
+      cmd: "${{ matrix.target.cmd }}"
+      dst: "${{ matrix.target.dst }}"
+      runner: "${{ matrix.target.runner }}"
+    strategy:
+      matrix:
+        target:
+          - id: go.drafter-nat
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-nat
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-forwarder
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-forwarder
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-agent
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-agent
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-liveness
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-liveness
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-snapshotter
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-snapshotter
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+          - id: go.drafter-peer
+            src: .
+            os: golang:bookworm
+            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
+            cmd: ./Hydrunfile go drafter-peer
+            dst: out/*
+            runner: depot-ubuntu-22.04-32
+
+  publish-binaries:
+    needs: build-binaries
+    uses: ./.github/workflows/publish.yaml
+    permissions:
+      id-token: write
+      contents: write
+    secrets: inherit
+
+  build-os:
+    needs: test
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    with:
+      id: "${{ matrix.target.id }}"
+      src: "${{ matrix.target.src }}"
+      os: "${{ matrix.target.os }}"
+      flags: "${{ matrix.target.flags }}"
+      cmd: "${{ matrix.target.cmd }}"
+      dst: "${{ matrix.target.dst }}"
+      runner: "${{ matrix.target.runner }}"
+    strategy:
+      matrix:
+        target:
+          # OCI OS
+          - id: os.drafteros-oci-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_defconfig drafteros-oci-x86_64.tar.zst
+            dst: out/drafteros-oci-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-oci-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_pvm_defconfig drafteros-oci-x86_64_pvm.tar.zst
+            dst: out/drafteros-oci-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-oci-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-oci-firecracker-aarch64_defconfig drafteros-oci-aarch64.tar.zst
+            dst: out/drafteros-oci-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # k3s Server OS
+          - id: os.drafteros-k3s-server-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_defconfig drafteros-k3s-server-x86_64.tar.zst
+            dst: out/drafteros-k3s-server-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-server-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_pvm_defconfig drafteros-k3s-server-x86_64_pvm.tar.zst
+            dst: out/drafteros-k3s-server-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-server-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-aarch64_defconfig drafteros-k3s-server-aarch64.tar.zst
+            dst: out/drafteros-k3s-server-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # k3s Client OS
+          - id: os.drafteros-k3s-client-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_defconfig drafteros-k3s-client-x86_64.tar.zst
+            dst: out/drafteros-k3s-client-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-client-x86_64_pvm
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_pvm_defconfig drafteros-k3s-client-x86_64_pvm.tar.zst
+            dst: out/drafteros-k3s-client-x86_64_pvm.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: os.drafteros-k3s-client-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
+            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-aarch64_defconfig drafteros-k3s-client-aarch64.tar.zst
+            dst: out/drafteros-k3s-client-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+          # OCI runtime bundles
+          - id: oci.valkey-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://valkey/valkey:latest amd64 oci-valkey-x86_64.tar.zst
+            dst: out/oci-valkey-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.valkey-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://valkey/valkey:latest arm64 oci-valkey-aarch64.tar.zst
+            dst: out/oci-valkey-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.postgres-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://postgres:latest amd64 oci-postgres-x86_64.tar.zst
+            dst: out/oci-postgres-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.postgres-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://postgres:latest arm64 oci-postgres-aarch64.tar.zst
+            dst: out/oci-postgres-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.ollama-x86_64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://ollama/ollama:latest amd64 oci-ollama-x86_64.tar.zst
+            dst: out/oci-ollama-x86_64.tar.zst
+            runner: depot-ubuntu-22.04-32
+          - id: oci.ollama-aarch64
+            src: .
+            os: fedora:42
+            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
+            cmd: ./Hydrunfile oci docker://ollama/ollama:latest arm64 oci-ollama-aarch64.tar.zst
+            dst: out/oci-ollama-aarch64.tar.zst
+            runner: depot-ubuntu-22.04-32
+
+  integration:
+    uses: ./.github/workflows/hydrun.yaml
+    secrets: inherit
+    concurrency:
+      group: integration # Only one integration test can run in the repository at a time across all refs
+    with:
+      id: "${{matrix.target.id}}"
+      src: "${{matrix.target.src}}"
+      os: "${{matrix.target.os}}"
+      flags: "${{matrix.target.flags}}"
+      cmd: "${{matrix.target.cmd}}"
+      dst: "${{matrix.target.dst}}"
+      runner: "${{matrix.target.runner}}"
+    strategy:
+      matrix:
+        target:
+          - id: "integration"
+            src: "."
+            os: fedora:42
+            flags: "-e '-v /tmp/ssh-key:/tmp/ssh-key -v /tmp/ccache:/root/.cache/go-build -v /tmp/google-credentials:/tmp/google-credentials'"
+            cmd: "./Hydrunfile integration"
+            dst: "out/nonexistent"
+            runner: "depot-ubuntu-22.04-32"
+
+  publish-os:
+    needs: build-os
+    uses: ./.github/workflows/publish.yaml
+    permissions:
+      id-token: write
+      contents: write
+    secrets: inherit

--- a/.github/workflows/drafter.yaml
+++ b/.github/workflows/drafter.yaml
@@ -1,4 +1,4 @@
-name: architect CI
+name: Drafter CI
 
 on:
   push:

--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -1,252 +1,76 @@
-name: hydrun CI
+name: Build with Hydrun
 
 on:
-  workflow_dispatch
-#  push:
-#    paths-ignore:
-#      - ".github/signatures/**"
-#  pull_request:
-#    paths-ignore:
-#      - ".github/signatures/**"
-#  schedule:
-#    - cron: "0 0 * * 0"
+  workflow_call:
+    inputs:
+      id:
+        type: string
+        required: true
+      src:
+        type: string
+        required: true
+      os:
+        type: string
+        required: true
+      flags:
+        type: string
+        required: false
+      cmd:
+        type: string
+        required: false
+      dst:
+        type: string
+        required: false
+      runner:
+        type: string
+        required: true
 
 jobs:
-  build-linux:
-    runs-on: ${{ matrix.target.runner }}
+  build:
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
-    strategy:
-      matrix:
-        target:
-          # Tests
-          - id: test
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build --privileged --cap-add=ALL -v /lib/modules:/lib/modules:ro -v /dev:/dev -v /var/run/docker.sock:/var/run/docker.sock --network host'
-            cmd: ./Hydrunfile test
-            dst: out/nonexistent
-            runner: depot-ubuntu-22.04-32
-
-          # Binaries
-          - id: go.drafter-nat
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-nat
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-forwarder
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-forwarder
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-agent
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-agent
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-liveness
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-liveness
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-snapshotter
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-snapshotter
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-          - id: go.drafter-peer
-            src: .
-            os: golang:bookworm
-            flags: -e '-v /tmp/ccache:/root/.cache/go-build'
-            cmd: ./Hydrunfile go drafter-peer
-            dst: out/*
-            runner: depot-ubuntu-22.04-32
-
-          # OCI OS
-          - id: os.drafteros-oci-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_defconfig drafteros-oci-x86_64.tar.zst
-            dst: out/drafteros-oci-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-oci-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-x86_64_pvm_defconfig drafteros-oci-x86_64_pvm.tar.zst
-            dst: out/drafteros-oci-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-oci-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-oci-firecracker-aarch64_defconfig drafteros-oci-aarch64.tar.zst
-            dst: out/drafteros-oci-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # k3s Server OS
-          - id: os.drafteros-k3s-server-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_defconfig drafteros-k3s-server-x86_64.tar.zst
-            dst: out/drafteros-k3s-server-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-server-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-x86_64_pvm_defconfig drafteros-k3s-server-x86_64_pvm.tar.zst
-            dst: out/drafteros-k3s-server-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-server-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-server-firecracker-aarch64_defconfig drafteros-k3s-server-aarch64.tar.zst
-            dst: out/drafteros-k3s-server-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # k3s Client OS
-          - id: os.drafteros-k3s-client-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_defconfig drafteros-k3s-client-x86_64.tar.zst
-            dst: out/drafteros-k3s-client-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-client-x86_64_pvm
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-x86_64_pvm_defconfig drafteros-k3s-client-x86_64_pvm.tar.zst
-            dst: out/drafteros-k3s-client-x86_64_pvm.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: os.drafteros-k3s-client-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build -v /tmp/ccache/buildroot:/root/.buildroot-ccache'
-            cmd: ./Hydrunfile os drafteros-k3s-client-firecracker-aarch64_defconfig drafteros-k3s-client-aarch64.tar.zst
-            dst: out/drafteros-k3s-client-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-
-          # OCI runtime bundles
-          - id: oci.valkey-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://valkey/valkey:latest amd64 oci-valkey-x86_64.tar.zst
-            dst: out/oci-valkey-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.valkey-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://valkey/valkey:latest arm64 oci-valkey-aarch64.tar.zst
-            dst: out/oci-valkey-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.postgres-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://postgres:latest amd64 oci-postgres-x86_64.tar.zst
-            dst: out/oci-postgres-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.postgres-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://postgres:latest arm64 oci-postgres-aarch64.tar.zst
-            dst: out/oci-postgres-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.ollama-x86_64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://ollama/ollama:latest amd64 oci-ollama-x86_64.tar.zst
-            dst: out/oci-ollama-x86_64.tar.zst
-            runner: depot-ubuntu-22.04-32
-          - id: oci.ollama-aarch64
-            src: .
-            os: fedora:41
-            flags: -e '-v /tmp/ccache/go:/root/.cache/go-build'
-            cmd: ./Hydrunfile oci docker://ollama/ollama:latest arm64 oci-ollama-aarch64.tar.zst
-            dst: out/oci-ollama-aarch64.tar.zst
-            runner: depot-ubuntu-22.04-32
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Restore ccache
         uses: actions/cache/restore@v4
         with:
           path: |
             /tmp/ccache
-          key: cache-ccache-${{ matrix.target.id }}
+          key: cache-ccache-${{ inputs.id }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Set up hydrun
         run: |
           curl -L -o /tmp/hydrun "https://github.com/pojntfx/hydrun/releases/latest/download/hydrun.linux-$(uname -m)"
           sudo install /tmp/hydrun /usr/local/bin
+
       - name: Build with hydrun
-        working-directory: ${{ matrix.target.src }}
-        run: hydrun -o ${{ matrix.target.os }} ${{ matrix.target.flags }} "${{ matrix.target.cmd }}"
+        working-directory: ${{ inputs.src }}
+        timeout-minutes: 120
+        run: |
+          hydrun -o ${{ inputs.os }} ${{ inputs.flags }} "${{ inputs.cmd }}"
+
       - name: Fix permissions for output
         run: sudo chown -R $USER .
+
       - name: Save ccache
         uses: actions/cache/save@v4
         with:
           path: |
             /tmp/ccache
-          key: cache-ccache-${{ matrix.target.id }}
+          key: cache-ccache-${{ inputs.id }}
+
       - name: Upload output
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target.id }}
-          path: ${{ matrix.target.dst }}
-
-  publish-linux:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: build-linux
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download output
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/out
-      - name: Extract branch name
-        id: extract_branch
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      - name: Publish pre-release to GitHub releases
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: release-${{ steps.extract_branch.outputs.branch }}
-          prerelease: true
-          files: |
-            /tmp/out/*/*
-      - name: Publish release to GitHub releases
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: false
-          files: |
-            /tmp/out/*/*
+          name: ${{ inputs.id }}
+          path: ${{ inputs.dst }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+name: Publish Artifacts
+
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download output
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/out
+
+      - name: Publish pre-release to GitHub releases
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ github.ref_name }}
+          prerelease: true
+          files: |
+            /tmp/out/*/*
+
+      - name: Publish release to GitHub releases
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          files: |
+            /tmp/out/*/*

--- a/Hydrunfile
+++ b/Hydrunfile
@@ -2,6 +2,8 @@
 
 set -e
 
+export CI=true
+
 # Test
 if [ "$1" = "test" ]; then
   # Install native dependencies
@@ -48,7 +50,7 @@ fi
 # OS
 if [ "$1" = "os" ]; then
   # Install native dependencies
-  dnf install -y @c-development @development-tools go curl make file cpio unzip rsync bc openssh-clients which wget perl
+  dnf install -y @c-development @development-tools go curl make file cpio unzip rsync bc openssh-clients which wget perl awk
 
   # Configure Git
   git config --global --add safe.directory '*'

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OCI_IMAGE_URI ?= docker://valkey/valkey:latest
 OCI_IMAGE_ARCHITECTURE ?= amd64
 OCI_IMAGE_HOSTNAME ?= drafterguest
 
-OS_URL ?= https://buildroot.org/downloads/buildroot-2024.11.tar.gz
+OS_URL ?= https://github.com/loopholelabs/buildroot/archive/8958adcacfec580cda9ee5ff049017a9f64a6996.tar.gz
 OS_DEFCONFIG ?= drafteros-oci-firecracker-x86_64_defconfig
 OS_BR2_EXTERNAL ?= ../../os
 

--- a/cmd/drafter-mignettest/util.go
+++ b/cmd/drafter-mignettest/util.go
@@ -18,7 +18,7 @@ import (
  *  - firecracker works
  *  - blueprints exist
  */
-func setupSnapshot(log types.Logger, ctx context.Context, snapDir string, blueDir string) error {
+func setupSnapshot(log types.Logger, ctx context.Context, snapDir string, blueDir string, inputKeepalive bool) error {
 	err := os.Mkdir(snapDir, 0777)
 	if err != nil {
 		return err
@@ -87,6 +87,7 @@ func setupSnapshot(log types.Logger, ctx context.Context, snapDir string, blueDi
 			Stdout:         os.Stdout,
 			Stderr:         os.Stderr,
 			Stdin:          nil,
+			InputKeepalive: inputKeepalive,
 		},
 		rfirecracker.NetworkConfiguration{
 			Interface: "tap0",

--- a/cmd/drafter-peer/main.go
+++ b/cmd/drafter-peer/main.go
@@ -46,6 +46,7 @@ func main() {
 	gid := flag.Int("gid", 0, "Group ID for the Firecracker process")
 	enableOutput := flag.Bool("enable-output", true, "Whether to enable VM stdout and stderr")
 	enableInput := flag.Bool("enable-input", false, "Whether to enable VM stdin")
+	inputKeepalive := flag.Bool("input-keepalive", true, "Whether to continously write backspace characters to the VM stdin to force the VM stdout to flush")
 	netns := flag.String("netns", "ark0", "Network namespace to run Firecracker in")
 	numaNode := flag.Int("numa-node", 0, "NUMA node to run Firecracker in")
 	cgroupVersion := flag.Int("cgroup-version", 2, "Cgroup version to use for Jailer")
@@ -136,6 +137,7 @@ func main() {
 		NetNS:          *netns,
 		NumaNode:       *numaNode,
 		CgroupVersion:  *cgroupVersion,
+		InputKeepalive: *inputKeepalive,
 	}
 
 	if *enableInput {

--- a/cmd/drafter-perf/main.go
+++ b/cmd/drafter-perf/main.go
@@ -49,6 +49,7 @@ func main() {
 
 	enableOutput := flag.Bool("enable-output", false, "Enable VM output")
 	enableInput := flag.Bool("enable-input", false, "Enable VM input")
+	inputKeepalive := flag.Bool("input-keepalive", true, "Whether to continously write backspace characters to the VM stdin to force the VM stdout to flush")
 
 	migrateAfter := flag.String("migrate-after", "", "Migrate the VM after a time period")
 
@@ -145,7 +146,7 @@ func main() {
 		}
 	}
 
-	err = setupSnapshot(log, ctx, netns, vmConfig, *dBlueDir, *dSnapDir, waitReady)
+	err = setupSnapshot(log, ctx, netns, vmConfig, *dBlueDir, *dSnapDir, waitReady, *inputKeepalive)
 	if err != nil {
 		panic(err)
 	}
@@ -231,7 +232,7 @@ func main() {
 			}
 		}
 
-		err = runSilo(ctx, log, dummyMetrics, *dTestDir, *dSnapDir, netns, benchCB, sConf, *enableInput, *enableOutput, *migrateAfter)
+		err = runSilo(ctx, log, dummyMetrics, *dTestDir, *dSnapDir, netns, benchCB, sConf, *enableInput, *enableOutput, *migrateAfter, *inputKeepalive)
 		if err != nil {
 			panic(err)
 		}
@@ -255,7 +256,7 @@ func main() {
 			}
 			nosiloRuntime = time.Since(ctime)
 		}
-		err = runNonSilo(ctx, log, *dTestDir, *dSnapDir, netns, benchCB, *enableInput, *enableOutput)
+		err = runNonSilo(ctx, log, *dTestDir, *dSnapDir, netns, benchCB, *enableInput, *enableOutput, *inputKeepalive)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/drafter-perf/runtime.go
+++ b/cmd/drafter-perf/runtime.go
@@ -54,7 +54,7 @@ func (sc *siloConfig) Summary() string {
  * runSilo runs a benchmark inside a VM with Silo
  *
  */
-func runSilo(ctx context.Context, log loggingtypes.Logger, met metrics.SiloMetrics, testDir string, snapDir string, netns string, benchCB func(), conf siloConfig, enableInput bool, enableOutput bool, migrateAfter string) error {
+func runSilo(ctx context.Context, log loggingtypes.Logger, met metrics.SiloMetrics, testDir string, snapDir string, netns string, benchCB func(), conf siloConfig, enableInput bool, enableOutput bool, migrateAfter string, inputKeepalive bool) error {
 	schemas := make(map[string]*config.DeviceSchema)
 
 	firecrackerBin, err := exec.LookPath("firecracker")
@@ -139,6 +139,7 @@ func runSilo(ctx context.Context, log loggingtypes.Logger, met metrics.SiloMetri
 		Stdout:         nil,
 		Stderr:         nil,
 		NoMapShared:    false,
+		InputKeepalive: inputKeepalive,
 	}
 
 	// If we're grabbing memory
@@ -258,7 +259,7 @@ func runSilo(ctx context.Context, log loggingtypes.Logger, met metrics.SiloMetri
  * Run a benchmark with Silo disabled.
  *
  */
-func runNonSilo(ctx context.Context, log loggingtypes.Logger, testDir string, snapDir string, netns string, benchCB func(), enableInput bool, enableOutput bool) error {
+func runNonSilo(ctx context.Context, log loggingtypes.Logger, testDir string, snapDir string, netns string, benchCB func(), enableInput bool, enableOutput bool, inputKeepalive bool) error {
 	// NOW TRY WITHOUT SILO
 	agentVsockPort := uint32(26)
 	agentLocal := struct{}{}
@@ -288,6 +289,7 @@ func runNonSilo(ctx context.Context, log loggingtypes.Logger, testDir string, sn
 		CgroupVersion:  2,
 		Stdout:         nil,
 		Stderr:         nil,
+		InputKeepalive: inputKeepalive,
 	}
 
 	if enableInput {

--- a/cmd/drafter-perf/util.go
+++ b/cmd/drafter-perf/util.go
@@ -21,7 +21,7 @@ import (
  *  - firecracker works
  *  - blueprints exist
  */
-func setupSnapshot(log loggingtypes.Logger, ctx context.Context, netns string, vmConfiguration rfirecracker.VMConfiguration, blueDir string, snapDir string, waitReady func()) error {
+func setupSnapshot(log loggingtypes.Logger, ctx context.Context, netns string, vmConfiguration rfirecracker.VMConfiguration, blueDir string, snapDir string, waitReady func(), inputKeepalive bool) error {
 	firecrackerBin, err := exec.LookPath("firecracker")
 	if err != nil {
 		return err
@@ -80,6 +80,7 @@ func setupSnapshot(log loggingtypes.Logger, ctx context.Context, netns string, v
 			Stdout:         nil,
 			Stderr:         nil,
 			Stdin:          nil,
+			InputKeepalive: inputKeepalive,
 		},
 		rfirecracker.NetworkConfiguration{
 			Interface: "tap0",

--- a/cmd/drafter-snapshotter/main.go
+++ b/cmd/drafter-snapshotter/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	enableOutput := flag.Bool("enable-output", true, "Whether to enable VM stdout and stderr")
 	enableInput := flag.Bool("enable-input", false, "Whether to enable VM stdin")
+	inputKeepalive := flag.Bool("input-keepalive", true, "Whether to continously write backspace characters to the VM stdin to force the VM stdout to flush")
 
 	resumeTimeout := flag.Duration("resume-timeout", time.Minute, "Maximum amount of time to wait for agent and liveness to resume")
 
@@ -107,6 +108,7 @@ func main() {
 		NetNS:          *netns,
 		NumaNode:       *numaNode,
 		CgroupVersion:  *cgroupVersion,
+		InputKeepalive: *inputKeepalive,
 	}
 
 	if *enableInput {


### PR DESCRIPTION
This adds an option to continuously write backspace characters to Firecracker's `stdin`. This fixes an issue where Firecracker (or the guest OS) don't seem to flush the stdout to the host after a while withou user input, which means that VM logs stop.