### PR TITLE
silo: set value for `AnyOrder` in incoming device

### DIFF
--- a/pkg/common/migrations.go
+++ b/pkg/common/migrations.go
@@ -200,6 +200,11 @@ func CreateIncomingSiloDevSchema(i *MigrateFromDevice, schema *config.DeviceSche
 		Size:      schema.Size,
 		Sync:      schema.Sync,
 	}
+	if i.AnyOrder {
+		ds.Migration = &config.MigrationConfigSchema{
+			AnyOrder: true,
+		}
+	}
 	if schema.Sync != nil {
 		ds.Sync.AutoStart = false
 	}


### PR DESCRIPTION
PR #99 added support for disabling Silo's volatility monitor by setting the flag `AnyOrder` in the device. But this flag was only being read in the outgoing device, resulting in the volatility monitor being used in the receiving end even if disabled.

Stack trace with `AnyOrder: true` from the sender:
![image](https://github.com/user-attachments/assets/af7d6efb-9a6e-4e38-a3b1-1959e972fba2)

And from the receiver:
![image](https://github.com/user-attachments/assets/548fbf72-2540-4bb6-8f98-ee58b3c35325)

